### PR TITLE
build(deps): bump logly from 0.1.1 to 0.1.5

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -33,8 +33,8 @@
     // internet connectivity.
     .dependencies = .{
         .logly = .{
-            .url = "https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.1.tar.gz",
-            .hash = "logly-0.1.1-kZjLe2KDCgBNLyamzCJxGAtlpQ2A27Knem0Izfo8bnmA",
+            .url = "https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.5.tar.gz",
+            .hash = "logly-0.1.5-kZjLe6PzEABxdqcu5UTmYOmkr7gwWcCYbazJn8pLIECs",
         },
     },
     .paths = .{


### PR DESCRIPTION
## Dependency Update: logly

Updates **[logly](https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.1.tar.gz)** from `0.1.1` to `0.1.5`.

### Details
- **Dependency**: logly
- **Repository**: https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.1.tar.gz
- **Update**: `0.1.1` -> `0.1.5`

### Verification
- [x] Update `build.zig.zon`
- [ ] Validation skipped

_Automated by [zig-dependabot](https://github.com/muhammad-fiaz/zig-dependabot)_